### PR TITLE
fix(api): handle empty palettes gracefully

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -46,12 +46,18 @@ func HashBytes(r io.Reader) int {
 
 // BytesToColor hashes the data from r and maps it to a color in p.
 func BytesToColor(p ColorSet, r io.Reader) color.Color {
+	if p.Len() == 0 {
+		return nil
+	}
 	i := HashBytes(r) % p.Len()
 	return p.Get(i)
 }
 
 // StringToColor hashes s and maps it to a color in p.
 func StringToColor(p ColorSet, s string) color.Color {
+	if p.Len() == 0 {
+		return nil
+	}
 	i := HashString(s) % p.Len()
 	return p.Get(i)
 }
@@ -59,6 +65,9 @@ func StringToColor(p ColorSet, s string) color.Color {
 // GetString hashes s and returns it wrapped in the corresponding
 // palette entry's ANSI escape codes.
 func (sp StringerPalette) GetString(s string) string {
+	if len(sp) == 0 {
+		return s
+	}
 	h := HashString(s)
 	h = h % len(sp)
 	return sp[h](s)

--- a/hash_test.go
+++ b/hash_test.go
@@ -114,6 +114,20 @@ func TestStringToColorDeterministic(t *testing.T) {
 	}
 }
 
+func TestStringToColorEmptyPalette(t *testing.T) {
+	var palette testPalette
+	if c := StringToColor(palette, "test"); c != nil {
+		t.Fatal("expected nil color for empty palette")
+	}
+}
+
+func TestBytesToColorEmptyPalette(t *testing.T) {
+	var palette testPalette
+	if c := BytesToColor(palette, bytes.NewReader([]byte("test"))); c != nil {
+		t.Fatal("expected nil color for empty palette")
+	}
+}
+
 func TestColorString(t *testing.T) {
 	result := Red("error")
 	if result == "" {
@@ -151,6 +165,13 @@ func TestStringerPalette(t *testing.T) {
 	result := sp.GetString("test")
 	if result == "" {
 		t.Fatal("GetString returned empty string")
+	}
+}
+
+func TestStringerPaletteEmpty(t *testing.T) {
+	var sp StringerPalette
+	if got := sp.GetString("plain"); got != "plain" {
+		t.Fatalf("expected unmodified string for empty palette, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- return nil from StringToColor and BytesToColor when the palette is empty
- return the original string from StringerPalette.GetString when the palette is empty
- add regression tests covering the empty-palette behavior

## Testing
- go test ./...
- go test -race ./...
- staticcheck ./...
- go test -cover ./...