### PR TITLE
fix(colors): normalize truecolor ANSI channels

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -108,7 +108,7 @@ func createStringerPalette(backgroundFillMode, disableSmartMode bool, c ...Color
 func trueColorString(color color.Color, backgroundFillMode, disableSmartMode bool) ColorStringer {
 	fgEsc, bgEsc := 38, 48
 	sprint := func(args ...interface{}) string {
-		r, g, b, _ := color.RGBA()
+		r, g, b := rgb8(color)
 		if !disableSmartMode {
 			return fmt.Sprintf("\033[;2;%d;%d;%d;m%s\033[0m\u001B[39m",
 				r, g, b,
@@ -126,6 +126,18 @@ func trueColorString(color color.Color, backgroundFillMode, disableSmartMode boo
 			esc+1)
 	}
 	return sprint
+}
+
+func rgb8(c color.Color) (r, g, b uint32) {
+	r, g, b, _ = c.RGBA()
+	return colorChannel8(r), colorChannel8(g), colorChannel8(b)
+}
+
+func colorChannel8(channel uint32) uint32 {
+	if channel > 0xff {
+		return channel / 0x101
+	}
+	return channel
 }
 
 // ColorStringer wraps a string in ANSI escape codes for terminal coloring.

--- a/colors.go
+++ b/colors.go
@@ -156,7 +156,7 @@ func ColorString(colorString string) ColorStringer {
 // GetBackgroundColor returns black or white depending on the perceived
 // luminance of c, suitable for readable text on a colored background.
 func GetBackgroundColor(c color.Color) color.Color {
-	red, green, blue, _ := c.RGBA()
+	red, green, blue := rgb8(c)
 	if (float32(red)*0.299 + float32(green)*0.587 + float32(blue)*0.114) > 150.0 {
 		return simplecolor.FromRGBA(0, 0, 0, 0)
 	}

--- a/hash_test.go
+++ b/hash_test.go
@@ -202,6 +202,14 @@ func TestCreateStringerPaletteDisableSmart(t *testing.T) {
 	}
 }
 
+func TestTrueColorStringNormalizesStandardColors(t *testing.T) {
+	result := trueColorString(color.RGBA{R: 255, G: 128, B: 64, A: 255}, false, true)("test")
+	expected := "\033[38;2;255;128;64;mtest\033[0m\u001B[39m"
+	if result != expected {
+		t.Fatalf("expected %q, got %q", expected, result)
+	}
+}
+
 func TestCreateStringerPaletteMultipleSets(t *testing.T) {
 	p1 := newTestPalette()
 	p2 := testPalette{

--- a/hash_test.go
+++ b/hash_test.go
@@ -235,6 +235,14 @@ func TestGetBackgroundColorMidTone(t *testing.T) {
 	}
 }
 
+func TestGetBackgroundColorNormalizesStandardColors(t *testing.T) {
+	bg := GetBackgroundColor(color.RGBA{R: 1, G: 1, B: 1, A: 255})
+	r, g, b, _ := bg.RGBA()
+	if r != 255 || g != 255 || b != 255 {
+		t.Fatalf("expected white background for very dark standard color, got (%d,%d,%d)", r, g, b)
+	}
+}
+
 func TestColorStringVariants(t *testing.T) {
 	variants := []struct {
 		name string


### PR DESCRIPTION
## Summary
- normalize truecolor ANSI RGB channels to 8-bit values before formatting escape codes
- preserve existing simplecolor behavior while supporting standard Go color.Color implementations
- add a regression test for color.RGBA input

## Verification
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -cover ./...