### PR TITLE
feat(api): export stringer palette constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ c := colorhash.StringToColor(flatui.Palette, "alice")
 palette := colorhash.GenerateOKLCHPalette(8, 0.7, 0.15)
 ```
 
+### Assign terminal colors from a palette
+
+```go
+sp := colorhash.CreateStringerPalette(palette)
+fmt.Println(sp.GetString("alice"))
+```
+
 ### Terminal color output
 
 ```go

--- a/colors.go
+++ b/colors.go
@@ -95,6 +95,24 @@ type ColorSet interface {
 // strings to colorized terminal output.
 type StringerPalette []ColorStringer
 
+// StringerPaletteOptions configures how stringer palettes emit ANSI colors.
+type StringerPaletteOptions struct {
+	BackgroundFillMode bool
+	DisableSmartMode   bool
+}
+
+// CreateStringerPalette returns a palette of ColorStringer functions using
+// foreground true-color ANSI escape codes.
+func CreateStringerPalette(c ...ColorSet) StringerPalette {
+	return CreateStringerPaletteWithOptions(StringerPaletteOptions{}, c...)
+}
+
+// CreateStringerPaletteWithOptions returns a palette of ColorStringer
+// functions configured with opts.
+func CreateStringerPaletteWithOptions(opts StringerPaletteOptions, c ...ColorSet) StringerPalette {
+	return createStringerPalette(opts.BackgroundFillMode, opts.DisableSmartMode, c...)
+}
+
 func createStringerPalette(backgroundFillMode, disableSmartMode bool, c ...ColorSet) StringerPalette {
 	palette := StringerPalette{}
 	for _, colorSet := range c {

--- a/hash_test.go
+++ b/hash_test.go
@@ -158,9 +158,9 @@ func TestGetBackgroundColor(t *testing.T) {
 
 func TestStringerPalette(t *testing.T) {
 	palette := newTestPalette()
-	sp := createStringerPalette(false, false, palette)
+	sp := CreateStringerPalette(palette)
 	if len(sp) == 0 {
-		t.Fatal("createStringerPalette returned empty palette")
+		t.Fatal("CreateStringerPalette returned empty palette")
 	}
 	result := sp.GetString("test")
 	if result == "" {
@@ -177,7 +177,7 @@ func TestStringerPaletteEmpty(t *testing.T) {
 
 func TestCreateStringerPaletteBackgroundFill(t *testing.T) {
 	palette := newTestPalette()
-	sp := createStringerPalette(true, false, palette)
+	sp := CreateStringerPaletteWithOptions(StringerPaletteOptions{BackgroundFillMode: true}, palette)
 	if len(sp) != len(palette) {
 		t.Fatalf("expected %d entries, got %d", len(palette), len(sp))
 	}
@@ -192,7 +192,7 @@ func TestCreateStringerPaletteBackgroundFill(t *testing.T) {
 
 func TestCreateStringerPaletteDisableSmart(t *testing.T) {
 	palette := newTestPalette()
-	sp := createStringerPalette(false, true, palette)
+	sp := CreateStringerPaletteWithOptions(StringerPaletteOptions{DisableSmartMode: true}, palette)
 	if len(sp) != len(palette) {
 		t.Fatalf("expected %d entries, got %d", len(palette), len(sp))
 	}
@@ -208,9 +208,16 @@ func TestCreateStringerPaletteMultipleSets(t *testing.T) {
 		simplecolor.FromRGBA(100, 100, 100, 255),
 		simplecolor.FromRGBA(200, 200, 200, 255),
 	}
-	sp := createStringerPalette(false, false, p1, p2)
+	sp := CreateStringerPalette(p1, p2)
 	if len(sp) != len(p1)+len(p2) {
 		t.Fatalf("expected %d entries, got %d", len(p1)+len(p2), len(sp))
+	}
+}
+
+func TestCreateStringerPaletteEmptySets(t *testing.T) {
+	sp := CreateStringerPalette()
+	if len(sp) != 0 {
+		t.Fatalf("expected empty stringer palette, got %d entries", len(sp))
 	}
 }
 


### PR DESCRIPTION
## Summary
- export `CreateStringerPalette` for the default foreground true-color behavior
- add `CreateStringerPaletteWithOptions` and `StringerPaletteOptions` for background/smart-mode configuration
- update tests and README to cover the public API path

## Verification
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -cover ./...
