### PR TITLE
feat(oklch): support hue-offset palette generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ c := colorhash.StringToColor(flatui.Palette, "alice")
 ```go
 // 8 evenly-spaced hues at lightness 0.7, chroma 0.15
 palette := colorhash.GenerateOKLCHPalette(8, 0.7, 0.15)
+
+// Rotate the starting hue by 30 degrees
+rotated := colorhash.GenerateOKLCHPaletteWithHueOffset(8, 0.7, 0.15, 30)
 ```
 
 ### Terminal color output

--- a/oklch.go
+++ b/oklch.go
@@ -3,6 +3,8 @@
 package colorhash
 
 import (
+	"math"
+
 	"github.com/taigrr/simplecolorpalettes/simplecolor"
 )
 
@@ -10,14 +12,28 @@ import (
 // at the given lightness and chroma. This produces a perceptually uniform palette
 // where all colors appear equally bright and saturated.
 func GenerateOKLCHPalette(n int, l, c float64) simplecolor.SimplePalette {
+	return GenerateOKLCHPaletteWithHueOffset(n, l, c, 0)
+}
+
+// GenerateOKLCHPaletteWithHueOffset generates n evenly-spaced colors in the
+// OKLCH color space, starting at startHue degrees.
+func GenerateOKLCHPaletteWithHueOffset(n int, l, c, startHue float64) simplecolor.SimplePalette {
 	if n <= 0 {
 		return simplecolor.SimplePalette{}
 	}
 	palette := make(simplecolor.SimplePalette, n)
 	step := 360.0 / float64(n)
 	for i := 0; i < n; i++ {
-		h := float64(i) * step
+		h := normalizeHue(startHue + float64(i)*step)
 		palette[i] = simplecolor.FromOKLCH(l, c, h)
 	}
 	return palette
+}
+
+func normalizeHue(h float64) float64 {
+	h = math.Mod(h, 360)
+	if h < 0 {
+		h += 360
+	}
+	return h
 }

--- a/oklch_test.go
+++ b/oklch_test.go
@@ -87,3 +87,56 @@ func TestGenerateOKLCHPaletteDistinct(t *testing.T) {
 		seen[int(c)] = true
 	}
 }
+
+func TestGenerateOKLCHPaletteWithHueOffset(t *testing.T) {
+	palette := GenerateOKLCHPaletteWithHueOffset(4, 0.7, 0.15, 30)
+	expectedHues := []float64{30, 120, 210, 300}
+
+	if len(palette) != len(expectedHues) {
+		t.Fatalf("expected %d colors, got %d", len(expectedHues), len(palette))
+	}
+	for i, c := range palette {
+		oklch := c.ToOKLCH()
+		if hueDiff(oklch.H, expectedHues[i]) > 10.0 {
+			t.Errorf("color %d: H = %f, expected ~%f", i, oklch.H, expectedHues[i])
+		}
+	}
+}
+
+func TestGenerateOKLCHPaletteWithHueOffsetWraps(t *testing.T) {
+	palette := GenerateOKLCHPaletteWithHueOffset(3, 0.7, 0.15, 390)
+	expectedHues := []float64{30, 150, 270}
+
+	if len(palette) != len(expectedHues) {
+		t.Fatalf("expected %d colors, got %d", len(expectedHues), len(palette))
+	}
+	for i, c := range palette {
+		oklch := c.ToOKLCH()
+		if hueDiff(oklch.H, expectedHues[i]) > 10.0 {
+			t.Errorf("color %d: H = %f, expected ~%f", i, oklch.H, expectedHues[i])
+		}
+	}
+}
+
+func TestGenerateOKLCHPaletteWithNegativeHueOffsetWraps(t *testing.T) {
+	palette := GenerateOKLCHPaletteWithHueOffset(2, 0.7, 0.15, -90)
+	expectedHues := []float64{270, 90}
+
+	if len(palette) != len(expectedHues) {
+		t.Fatalf("expected %d colors, got %d", len(expectedHues), len(palette))
+	}
+	for i, c := range palette {
+		oklch := c.ToOKLCH()
+		if hueDiff(oklch.H, expectedHues[i]) > 10.0 {
+			t.Errorf("color %d: H = %f, expected ~%f", i, oklch.H, expectedHues[i])
+		}
+	}
+}
+
+func hueDiff(a, b float64) float64 {
+	diff := math.Abs(a - b)
+	if diff > 180 {
+		diff = 360 - diff
+	}
+	return diff
+}


### PR DESCRIPTION
## Summary

- add GenerateOKLCHPaletteWithHueOffset for rotated OKLCH palettes
- normalize positive and negative hue offsets into the 0-360 range
- document the new helper and cover offset/wrapping behavior with tests

## Tests

- go generate ./...
- go test -race ./...
- staticcheck ./...
