### PR TITLE
feat(api): expose reader hash errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ import (
 c := colorhash.StringToColor(flatui.Palette, "alice")
 ```
 
+### Hash a byte stream
+
+```go
+hash, err := colorhash.HashReader(reader)
+if err != nil {
+    return err
+}
+fmt.Println(hash)
+```
+
 ### Generate an OKLCH palette
 
 ```go

--- a/hash.go
+++ b/hash.go
@@ -1,7 +1,6 @@
 package colorhash
 
 import (
-	"encoding/binary"
 	"hash/fnv"
 	"image/color"
 	"io"
@@ -19,25 +18,26 @@ const (
 func HashString(s string) int {
 	h := fnv.New64()
 	io.WriteString(h, s)
-	hashb := h.Sum(nil)
-	hashb = hashb[len(hashb)-8:]
-	lsb := binary.BigEndian.Uint64(hashb)
-	sint := int(lsb)
-	if sint < 0 {
-		sint = sint + MaxInt
-	}
-	return sint
+	return hashSumToInt(h.Sum64())
 }
 
 // HashBytes returns a deterministic non-negative integer hash of the
 // data read from r using FNV-64.
 func HashBytes(r io.Reader) int {
+	sum, _ := HashReader(r)
+	return sum
+}
+
+// HashReader returns a deterministic non-negative integer hash of the
+// data read from r using FNV-64, along with any read error encountered.
+func HashReader(r io.Reader) (int, error) {
 	h := fnv.New64()
-	io.Copy(h, r)
-	hashb := h.Sum(nil)
-	hashb = hashb[len(hashb)-8:]
-	lsb := binary.BigEndian.Uint64(hashb)
-	sint := int(lsb)
+	_, err := io.Copy(h, r)
+	return hashSumToInt(h.Sum64()), err
+}
+
+func hashSumToInt(sum uint64) int {
+	sint := int(sum)
 	if sint < 0 {
 		sint = sint + MaxInt
 	}

--- a/hash_test.go
+++ b/hash_test.go
@@ -2,6 +2,7 @@ package colorhash
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"image/color"
 	"testing"
@@ -75,6 +76,31 @@ func TestHashBytes(t *testing.T) {
 	expected := HashString("hello colorhash")
 	if h != expected {
 		t.Errorf("HashBytes and HashString diverged for same input: %d != %d", h, expected)
+	}
+}
+
+func TestHashReader(t *testing.T) {
+	input := []byte("hello colorhash")
+	h, err := HashReader(bytes.NewReader(input))
+	if err != nil {
+		t.Fatalf("HashReader returned unexpected error: %v", err)
+	}
+	expected := HashString("hello colorhash")
+	if h != expected {
+		t.Errorf("HashReader and HashString diverged for same input: %d != %d", h, expected)
+	}
+}
+
+func TestHashReaderReturnsReadError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	reader := errorReader{data: []byte("partial"), err: wantErr}
+
+	got, err := HashReader(reader)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected read error %v, got %v", wantErr, err)
+	}
+	if got != HashString("partial") {
+		t.Fatalf("expected partial-data hash %d, got %d", HashString("partial"), got)
 	}
 }
 
@@ -338,4 +364,13 @@ func TestDifferentInputsDifferentColors(t *testing.T) {
 	if len(colors) < 2 {
 		t.Errorf("expected multiple distinct colors, got %d", len(colors))
 	}
+}
+
+type errorReader struct {
+	data []byte
+	err  error
+}
+
+func (r errorReader) Read(p []byte) (int, error) {
+	return copy(p, r.data), r.err
 }


### PR DESCRIPTION
## Summary

- add `HashReader` for callers that need the hash plus any reader error
- keep `HashBytes` as the backward-compatible best-effort wrapper
- add coverage for successful reader hashing and partial-data read failures

## Tests

- go generate ./...
- go build ./...
- go test -race ./...
- go vet ./...
- staticcheck ./...