### PR TITLE
test(docs): add public api examples

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,38 @@
+package colorhash_test
+
+import (
+	"fmt"
+	"image/color"
+
+	"github.com/taigrr/colorhash"
+	"github.com/taigrr/simplecolorpalettes/simplecolor"
+)
+
+type examplePalette []color.Color
+
+func (p examplePalette) ToPalette() color.Palette { return color.Palette(p) }
+func (p examplePalette) Get(i int) color.Color    { return p[i] }
+func (p examplePalette) Len() int                 { return len(p) }
+
+func ExampleHashString() {
+	fmt.Println(colorhash.HashString("hello colorhash"))
+	// Output: 893132354324239557
+}
+
+func ExampleStringToColor() {
+	palette := examplePalette{
+		simplecolor.FromRGBA(255, 0, 0, 255),
+		simplecolor.FromRGBA(0, 255, 0, 255),
+		simplecolor.FromRGBA(0, 0, 255, 255),
+	}
+
+	c := colorhash.StringToColor(palette, "alice")
+	fmt.Println(c == nil)
+	// Output: false
+}
+
+func ExampleGenerateOKLCHPalette() {
+	palette := colorhash.GenerateOKLCHPalette(8, 0.7, 0.15)
+	fmt.Println(palette.Len())
+	// Output: 8
+}


### PR DESCRIPTION
## Summary

- add executable Go doc examples for HashString, StringToColor, and GenerateOKLCHPalette
- show external callers how to satisfy the ColorSet interface
- keep the examples covered by go test so docs stay accurate

## Tests

- go generate ./...
- go build ./...
- go test -race ./...
- go vet ./...
- staticcheck ./...
- go test -cover ./...